### PR TITLE
Convert README to GitHub markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ exampleEnum.EnumWithAStringValueDefined.GetStringValue()
                // returns "1"
 
 exampleEnum.EnumWithMultipleStringValueDefinedAndOneMarkedAsPreferred.GetStringValue() 
-               // returns "4"
+               // returns "2"
 
 
 /* Map from string to Enum. */


### PR DESCRIPTION
It's more conventional for GitHub "README" files to use markdown syntax. This makes the repos prettier when you visit it in GitHub's website.

I've included 3 commits in this pull request (see list below)
The first has no content changes here, just markup changes.
The second and third should hopefully be self-explanatory.
